### PR TITLE
Fix photos not loading (https://github.com/Wert22/wert-camera/issues/4)

### DIFF
--- a/wert-camera/client.lua
+++ b/wert-camera/client.lua
@@ -150,7 +150,7 @@ RegisterNetEvent("wert-camera:client:use-camera", function()
 						exports['screenshot-basic']:requestScreenshotUpload(tostring(hook), "files[]", function(data)
                                     			local image = json.decode(data)
                                     			FullClose()
-                                    			TriggerServerEvent("wert-camera:server:add-photo-item", json.encode(image.attachments[1].proxy_url))
+                                    			TriggerServerEvent("wert-camera:server:add-photo-item", json.encode(image.attachments[1].url))
                                 		end)						
 					end
 				end)


### PR DESCRIPTION
Property proxy_url changed to url due to some changes in discord
* You have to maeke new photos to make it work. Still will not work with old pictures in your inventory.